### PR TITLE
Allow yes/no in missing_track_playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [RED]list is a tool to glue together Spotify, [Beets](https://beets.io), and [REDACTED].
 
 ## Installation
-[RED]list requires python 3.6+. 
+[RED]list requires python 3.6+.
 
 [RED]list also expects you to have a populated [Beets](https://beets.io)
 library. It will use it to find and match your music files.
@@ -48,12 +48,12 @@ optional arguments:
                         Set the log level. (Default: INFO)
 ```
 
-Where playlist is a Spotify playlist (uri or url), an m3u, or a csv file (artist, title, album). 
+Where playlist is a Spotify playlist (uri or url), an m3u, or a csv file (artist, title, album).
 
 [RED]list will use your local beets library (located automatically) and do it's best to
 match tracks from the playlist to tracks in your library and write the results to m3u. Any
 missing tracks can then be automatically searched for on [REDACTED] and torrents will be
-downloaded or, if you use deluge, added to a running deluge instance. 
+downloaded or, if you use deluge, added to a running deluge instance.
 
 [RED]list can then be re-run any time on the created m3u playlist to re-match any
 previously missing files.
@@ -102,7 +102,7 @@ torrent_directory: null      # Directory save downloaded torrents
 m3u_directory: null          # Directory to save processed m3u playlists
 restrict_album: no           # Only allow tracks to match if they are from the same album
 overwrite_m3u: no            # If argument is m3u, overwrite it instead of saving to m3u_dir
-missing_track_playlist: null # set to a value to have redlist ask to create a spotify playlist of missing tracks
+missing_track_playlist: null # Whether redlist should create a spotify playlist of missing tracks. `yes`, `no` or any other value for manual confirmation
 
 redacted:
   disable: no                # Disable [REDACTED] search entirely.
@@ -157,7 +157,7 @@ redacted:
 This will set [RED]list to automatically add torrents to a deluge server running at
 example.com. By setting `missing_track_playlist` [RED]list will prompt the user if they
 want to create a spotify playlist containing tracks that couldn't be found (could be set
-to `yes` to do so automatically). 
+to `yes` to do so automatically).
 
 It also specifies the preferred torrent formats. The preferences are listed as regex
 strings in the preferred order. The regex strings are matched against a string of the

--- a/redlist/__main__.py
+++ b/redlist/__main__.py
@@ -259,19 +259,32 @@ async def main(spotlist, yes=False):
             )
             for t in unmatched:
                 print(t)
+
+    # Check whether a spotify playlist with the missing songs shall be created.
     missing_track_playlist = config["missing_track_playlist"].get()
-    if (
-        (missing_track_playlist == "yes" and missing_track_playlist != "no")
-        or missing_track_playlist is not None
-        or re.match(
-            r"y",
-            input(
-                "\nWould you like to create a new spotify playlist with the missing tracks?(y/n): "
-            ),
-            flags=re.I,
-        )
-    ):
+    create_spotify_playlist = False
+    if missing_track_playlist == "yes":
+        create_spotify_playlist = True
+    elif missing_track_playlist != "no":
+        pass
+    else:
+        # If the value is anything else, ask the user.
+        if (
+            missing_track_playlist is not None
+            and yes
+            or re.match(
+                r"y",
+                input(
+                    "\nWould you like to create a new spotify playlist with the missing tracks?(y/n): "
+                ),
+                flags=re.I,
+            )
+        ):
+            create_spotify_playlist = True
+
+    if create_spotify_playlist:
         await playlist.make_missing_spotify_playlist(playlist_title, unmatched)
+
     print("Finished.")
     return 0
 


### PR DESCRIPTION
The previous logic did use an `or` for all conditions, which resulted in the prompt to always appear, even if the value wasn't set or set to `no`

The new logic interprets `yes`/`no` as definitive answers, with `None` being equivalent to `no`.
Any other value results in a prompt, which respects the `-y` flag.

Cheers