### PR TITLE
feat: Single-threaded redlist lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ redacted:
   api_key: null              # Preferred method. Go to User Settings > API Keys and confirm a new key.
   username: null
   password: null
+  single_threaded: no        # Enable to get sequentially readable logs, but slower redacted API lookup.
   save_cookies: yes
   use_fl_tokens: no          # Use freeleach tokens (slows downloads SIGNIFICANTLY)
   format_preferences:        # "Format Encoding Media"

--- a/redlist/__main__.py
+++ b/redlist/__main__.py
@@ -47,17 +47,27 @@ async def search_redlist_and_dl(unmatched, yes=False):
             log.debug("Stack Trace:", exc_info=True)
             return None
 
-    tasks = {}
-    for track in unmatched:
-        task = asyncio.ensure_future(safe_find_album(track, api))
-        tasks[track] = task
+    results = {}
     match_start = time.monotonic()
-    await asyncio.gather(*tasks.values())
+    # Searching for redacted releases in parallel results in the logs of the
+    # different lookups to be jumbled, which makes them virtually unusable.
+    # For debugging/understanding how decisions were made, users can set
+    # the "single_threaded" option to limit lookup to a single task at a time.
+    if config["redacted"]["single_threaded"]:
+        for track in unmatched:
+            results[track] = await safe_find_album(track, api)
+    else:
+        tasks = {}
+        for track in unmatched:
+            task = asyncio.ensure_future(safe_find_album(track, api))
+            tasks[track] = task
+        await asyncio.gather(*tasks.values())
+        results = {t: v.result() for t, v in tasks.items()}
+
     match_end = time.monotonic()
     log.info(
         "Searching complete after %s!", humanize.naturaldelta(match_end - match_start)
     )
-    results = {t: v.result() for t, v in tasks.items()}
     missing = [t for t, v in results.items() if v is None]
     log.info(
         "Found matches for %d/%d unmatched tracks",

--- a/redlist/config_default.yaml
+++ b/redlist/config_default.yaml
@@ -13,9 +13,10 @@ redacted:
   api_key: null
   username: null
   password: null
+  single_threaded: no
   save_cookies: yes
   use_fl_tokens: no
-  format_preferences:  # "Format Encoding Media"
+  format_preferences: # "Format Encoding Media"
     - 'MP3 V0'
     - 'MP3 320'
     - 'FLAC .*'


### PR DESCRIPTION
Heyo :)

I found myself looking at the logs quite a bit to understand which track caused a certain release to be selected.
Since the tasks are handled in parallel, this is pretty rough to do in the log output.

Since waiting a bit longer is not really an issue for me, I decided to add a flag that results in one lookup at a time. The name `single_threaded` is obviously technically wrong, but (for me) it conveyed the meaning of that flag the best :D. 

Let me know whether you think this might be useful! If not, just close the MR.

Cheers